### PR TITLE
Increase footer margin for PDF generation

### DIFF
--- a/workflow.json
+++ b/workflow.json
@@ -451,7 +451,7 @@
             },
             {
               "name": "marginBottom",
-              "value": "15mm"
+              "value": "35mm"
             },
             {
               "name": "marginLeft",


### PR DESCRIPTION
## Summary
- enlarge `marginBottom` in workflow PDF generation step to allow footer content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -X POST "https://gotenberg-liwwwqwh3q-ey.a.run.app/forms/chromium/convert/html" ...` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fe9df5088327bebefa8185cf5cbc